### PR TITLE
Add collaborators information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val `sbt-me` = project
       "org.http4s" %% "http4s-blaze-server" % "0.20.15" % Test
     ),
     mdocVariables := Map(
-      "VERSION"      -> version.value.replaceAll("\\+.*", ""),
-      "CONTRIBUTORS" -> contributors.value.markdown
+      "VERSION"       -> version.value.replaceAll("\\+.*", ""),
+      "CONTRIBUTORS"  -> contributors.value.markdown,
+      "COLLABORATORS" -> collaborators.value.markdown
     )
   )

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,5 +1,11 @@
 # Authors
 
+## Maintainers
+
+The maintainers of the project are:
+
+@COLLABORATORS@
+
 ## Contributors
 
 These are the people that have contributed to the _sbt-me_ project:

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -29,6 +29,9 @@ object SbtMePlugin extends AutoPlugin {
     type Collaborators = github.Collaborators
     val Collaborators = github.Collaborators
 
+    type Collaborator = github.Collaborator
+    val Collaborator = github.Collaborator
+
     val contributors = settingKey[Contributors](
       "List of contributors downloaded from Github"
     )
@@ -36,6 +39,10 @@ object SbtMePlugin extends AutoPlugin {
     val collaborators = settingKey[Collaborators](
       "List of collaborators downloaded from Github"
     )
+
+    val extraCollaborators = settingKey[List[Collaborator]] {
+      "Extra collaborators that should be always included (independent of whether they are contributors or not)"
+    }
 
     val excludedContributors = settingKey[List[String]] {
       "ID (Github login) of the contributors that should be excluded from the list, like bots"
@@ -60,6 +67,7 @@ object SbtMePlugin extends AutoPlugin {
   override def globalSettings: Seq[Setting[_]] = Seq(
     downloadInfoFromGithub := sys.env.contains("RELEASE"),
     excludedContributors   := List("scala-steward", "mergify[bot]"),
+    extraCollaborators     := List(),
     repository := {
       if (downloadInfoFromGithub.value)
         Some(Repository.get(user, repo).fold(sys.error, identity))
@@ -69,7 +77,9 @@ object SbtMePlugin extends AutoPlugin {
       _.contributors(excludedContributors.value).fold(sys.error, identity)
     },
     collaborators := repository.value.fold(Collaborators(Nil)) {
-      _.collaborators(contributors.value.list.map(_.login)).fold(sys.error, identity)
+      _.collaborators(contributors.value.list.map(_.login))
+        .fold(sys.error, identity)
+        .include(extraCollaborators.value)
     },
     homepage  := repository.value.map(r => url(r.url)).orElse(homepage.value),
     licenses  := repository.value.map(_.licenses).getOrElse(licenses.value),

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -69,7 +69,7 @@ object SbtMePlugin extends AutoPlugin {
       _.contributors(excludedContributors.value).fold(sys.error, identity)
     },
     collaborators := repository.value.fold(Collaborators(Nil)) {
-      _.collaborators.fold(sys.error, identity)
+      _.collaborators(contributors.value.list.map(_.login)).fold(sys.error, identity)
     },
     homepage  := repository.value.map(r => url(r.url)).orElse(homepage.value),
     licenses  := repository.value.map(_.licenses).getOrElse(licenses.value),

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -26,8 +26,15 @@ object SbtMePlugin extends AutoPlugin {
     type Contributors = github.Contributors
     val Contributors = github.Contributors
 
+    type Collaborators = github.Collaborators
+    val Collaborators = github.Collaborators
+
     val contributors = settingKey[Contributors](
       "List of contributors downloaded from Github"
+    )
+
+    val collaborators = settingKey[Collaborators](
+      "List of collaborators downloaded from Github"
     )
 
     val excludedContributors = settingKey[List[String]] {
@@ -60,6 +67,9 @@ object SbtMePlugin extends AutoPlugin {
     },
     contributors := repository.value.fold(Contributors(Nil)) {
       _.contributors(excludedContributors.value).fold(sys.error, identity)
+    },
+    collaborators := repository.value.fold(Collaborators(Nil)) {
+      _.collaborators.fold(sys.error, identity)
     },
     homepage  := repository.value.map(r => url(r.url)).orElse(homepage.value),
     licenses  := repository.value.map(_.licenses).getOrElse(licenses.value),

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -4,7 +4,7 @@ import com.alejandrohdezma.sbt.me.json.Decoder
 import com.alejandrohdezma.sbt.me.syntax.json._
 
 /** Represents a repository collaborator */
-final case class Collaborator(
+final case class Collaborator private[me] (
     login: String,
     url: String,
     userUrl: String,
@@ -14,6 +14,26 @@ final case class Collaborator(
 )
 
 object Collaborator {
+
+  /**
+   * Creates a new collaborator
+   *
+   * @param login the Github login ID for the collaborator
+   * @param url the collaborator's URL. It may link to its Github profile or personal webpage, optional
+   * @param name the collaborator's full name
+   * @param email the collaborator's email
+   * @param avatar the collaborator's avatar URL, optional
+   * @return a new collaborator
+   */
+  @SuppressWarnings(Array("scalafix:DisableSyntax.defaultArgs"))
+  def apply(
+      login: String,
+      name: String,
+      email: String,
+      url: Option[String] = None,
+      avatar: Option[String] = None
+  ): Collaborator =
+    new Collaborator(login, url.getOrElse(""), "", Some(name), Some(email), avatar)
 
   implicit val CollaboratorDecoder: Decoder[Collaborator] = json =>
     for {

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -1,0 +1,22 @@
+package com.alejandrohdezma.sbt.me.github
+
+import com.alejandrohdezma.sbt.me.json.Decoder
+import com.alejandrohdezma.sbt.me.syntax.json._
+
+/** Represents a repository collaborator */
+final case class Collaborator(
+    login: String,
+    url: String,
+    avatar: Option[String]
+)
+
+object Collaborator {
+
+  implicit val CollaboratorDecoder: Decoder[Collaborator] = json =>
+    for {
+      login  <- json.get[String]("login")
+      url    <- json.get[String]("html_url")
+      avatar <- json.get[Option[String]]("avatar_url")
+    } yield Collaborator(login, url, avatar.filter(_.nonEmpty))
+
+}

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -8,6 +8,8 @@ final case class Collaborator(
     login: String,
     url: String,
     userUrl: String,
+    name: Option[String],
+    email: Option[String],
     avatar: Option[String]
 )
 
@@ -19,6 +21,6 @@ object Collaborator {
       url     <- json.get[String]("html_url")
       userUrl <- json.get[String]("url")
       avatar  <- json.get[Option[String]]("avatar_url")
-    } yield Collaborator(login, url, userUrl, avatar.filter(_.nonEmpty))
+    } yield Collaborator(login, url, userUrl, None, None, avatar.filter(_.nonEmpty))
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -7,6 +7,7 @@ import com.alejandrohdezma.sbt.me.syntax.json._
 final case class Collaborator(
     login: String,
     url: String,
+    userUrl: String,
     avatar: Option[String]
 )
 
@@ -14,9 +15,10 @@ object Collaborator {
 
   implicit val CollaboratorDecoder: Decoder[Collaborator] = json =>
     for {
-      login  <- json.get[String]("login")
-      url    <- json.get[String]("html_url")
-      avatar <- json.get[Option[String]]("avatar_url")
-    } yield Collaborator(login, url, avatar.filter(_.nonEmpty))
+      login   <- json.get[String]("login")
+      url     <- json.get[String]("html_url")
+      userUrl <- json.get[String]("url")
+      avatar  <- json.get[Option[String]]("avatar_url")
+    } yield Collaborator(login, url, userUrl, avatar.filter(_.nonEmpty))
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
@@ -1,4 +1,16 @@
 package com.alejandrohdezma.sbt.me.github
 
 /** Represents a repository's list of collaborators */
-final case class Collaborators(list: List[Collaborator])
+final case class Collaborators(list: List[Collaborator]) {
+
+  /** Includes the provided list of collaborators to the current list, removing duplicates */
+  private[me] def include(collaborators: List[Collaborator]): Collaborators = Collaborators {
+    (list ++ collaborators)
+      .groupBy(_.login)
+      .values
+      .toList
+      .map(_.head) /* scalafix:ok */
+      .sortBy(collaborator => collaborator.name -> collaborator.login)
+  }
+
+}

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
@@ -13,4 +13,21 @@ final case class Collaborators(list: List[Collaborator]) {
       .sortBy(collaborator => collaborator.name -> collaborator.login)
   }
 
+  /** Returns this list of collaborators in markdown format */
+  lazy val markdown: String =
+    list.map { collaborator =>
+      import collaborator._
+
+      val image = avatar.map(avatarUrl => s"![$login]($avatarUrl&s=20) ").getOrElse("")
+
+      val definitiveName = name.filter(_.nonEmpty).getOrElse(login)
+
+      val prettyName =
+        if (definitiveName.contentEquals(login)) login else s"$definitiveName ($login)"
+
+      Option(url)
+        .filter(_.nonEmpty)
+        .fold(s"""- $image**$prettyName**""")(u => s"""- [$image**$prettyName**]($u)""")
+    }.mkString("\n")
+
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
@@ -1,0 +1,4 @@
+package com.alejandrohdezma.sbt.me.github
+
+/** Represents a repository's list of collaborators */
+final case class Collaborators(list: List[Collaborator])

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
@@ -41,6 +41,18 @@ final case class Repository(
       .leftMap(_ => "Unable to get repository contributors")
   }
 
+  /**
+   * Returns the list of repository collaborators, alphabetically ordered.
+   */
+  def collaborators(
+      implicit auth: Authentication
+  ): Either[String, Collaborators] =
+    client
+      .get[List[Collaborator]](collaboratorsUrl)
+      .map(_.sortBy(_.login))
+      .map(Collaborators)
+      .leftMap(_ => "Unable to get repository collaborators")
+
 }
 
 object Repository {
@@ -70,6 +82,13 @@ object Repository {
       startYear     <- json.get[ZonedDateTime]("created_at")
       contributors  <- json.get[String]("contributors_url")
       collaborators <- json.get[String]("collaborators_url")
-    } yield Repository(description, license, url, startYear.getYear, contributors, collaborators)
+    } yield Repository(
+      description,
+      license,
+      url,
+      startYear.getYear,
+      contributors,
+      collaborators.replace("{/collaborator}", "")
+    )
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
@@ -16,7 +16,8 @@ final case class Repository(
     license: License,
     url: String,
     startYear: Int,
-    contributorsUrl: String
+    contributorsUrl: String,
+    collaboratorsUrl: String
 ) {
 
   /** Returns the license extracted from github in the format that SBT is expecting */
@@ -63,11 +64,12 @@ object Repository {
 
   implicit val RepositoryDecoder: Decoder[Repository] = json =>
     for {
-      description     <- json.get[String]("description")
-      license         <- json.get[License]("license")
-      url             <- json.get[String]("html_url")
-      startYear       <- json.get[ZonedDateTime]("created_at")
-      contributorsUrl <- json.get[String]("contributors_url")
-    } yield Repository(description, license, url, startYear.getYear, contributorsUrl)
+      description   <- json.get[String]("description")
+      license       <- json.get[License]("license")
+      url           <- json.get[String]("html_url")
+      startYear     <- json.get[ZonedDateTime]("created_at")
+      contributors  <- json.get[String]("contributors_url")
+      collaborators <- json.get[String]("collaborators_url")
+    } yield Repository(description, license, url, startYear.getYear, contributors, collaborators)
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
@@ -42,13 +42,15 @@ final case class Repository(
   }
 
   /**
-   * Returns the list of repository collaborators, alphabetically ordered.
+   * Returns the list of repository collaborators, filtered by those who have contributed
+   * at least once to the project, alphabetically ordered.
    */
-  def collaborators(
+  def collaborators(allowed: List[String])(
       implicit auth: Authentication
   ): Either[String, Collaborators] =
     client
       .get[List[Collaborator]](collaboratorsUrl)
+      .map(_.filter(m => allowed.contains(m.login)))
       .map(_.sortBy(_.login))
       .map(Collaborators)
       .leftMap(_ => "Unable to get repository collaborators")

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
@@ -11,6 +11,6 @@ object User {
     for {
       name  <- json.get[Option[String]]("name")
       email <- json.get[Option[String]]("email")
-    } yield User(name, email)
+    } yield User(name.filter(_.nonEmpty), email.filter(_.nonEmpty))
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
@@ -1,0 +1,16 @@
+package com.alejandrohdezma.sbt.me.github
+
+import com.alejandrohdezma.sbt.me.json.Decoder
+import com.alejandrohdezma.sbt.me.syntax.json._
+
+final case class User(name: Option[String], email: Option[String])
+
+object User {
+
+  implicit val decoder: Decoder[User] = json =>
+    for {
+      name  <- json.get[Option[String]]("name")
+      email <- json.get[Option[String]]("email")
+    } yield User(name, email)
+
+}

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -49,4 +49,37 @@ class CollaboratorsSpec extends Specification {
 
   }
 
+  "Collaborators.markdown" should {
+
+    "return contributor list as markdown" >> {
+      val collaborators = Collaborators(
+        List(
+          Collaborator("her", "Her", "her@example.com", avatar = Some("example.com/her.png")),
+          Collaborator("him", "Him", "him@example.com"),
+          Collaborator(
+            "it",
+            "It",
+            "it@example.com",
+            Some("example.com/it"),
+            Some("example.com/it.png")
+          ),
+          Collaborator("me", "Me", "me@example.com", Some("example.com/me")),
+          Collaborator("you", "", "you@example.com")
+        )
+      )
+
+      val markdown = collaborators.markdown
+
+      val expected =
+        """- ![her](example.com/her.png&s=20) **Her (her)**
+          |- **Him (him)**
+          |- [![it](example.com/it.png&s=20) **It (it)**](example.com/it)
+          |- [**Me (me)**](example.com/me)
+          |- **you**""".stripMargin
+
+      markdown must be equalTo expected
+    }
+
+  }
+
 }

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -1,0 +1,52 @@
+package com.alejandrohdezma.sbt.me.github
+
+import org.specs2.mutable.Specification
+
+class CollaboratorsSpec extends Specification {
+
+  "Collaborators.include" should {
+
+    "return list of collaborators including new ones" >> {
+      val collaborators = Collaborators(
+        List(
+          Collaborator("me", "Me", "me@example.com"),
+          Collaborator("you", "You", "you@example.com")
+        )
+      )
+
+      val extra = List(Collaborator("him", "Him", "him@example.com"))
+
+      val expected = Collaborators(
+        List(
+          Collaborator("him", "Him", "him@example.com"),
+          Collaborator("me", "Me", "me@example.com"),
+          Collaborator("you", "You", "you@example.com")
+        )
+      )
+
+      collaborators.include(extra) must be equalTo expected
+    }
+
+    "remove duplicates" >> {
+      val collaborators = Collaborators(
+        List(
+          Collaborator("me", "Me", "me@example.com"),
+          Collaborator("you", "You", "you@example.com")
+        )
+      )
+
+      val extra = List(Collaborator("me", "MeMe", "meme@example.com"))
+
+      val expected = Collaborators(
+        List(
+          Collaborator("me", "Me", "me@example.com"),
+          Collaborator("you", "You", "you@example.com")
+        )
+      )
+
+      collaborators.include(extra) must be equalTo expected
+    }
+
+  }
+
+}

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
@@ -231,17 +231,20 @@ class RepositorySpec extends Specification {
         Ok("""[
           {
             "login": "me",
-            "avatar_url": "http://example.com/me.png",
-            "html_url": "http://example.com/me"
+            "avatar_url": "example.com/me.png",
+            "html_url": "example.com/me",
+            "url": "api.example.com/me"
           },
           {
             "login": "you",
-            "html_url": "http://example.com/you"
+            "html_url": "example.com/you",
+            "url": "api.example.com/you"
           },
           {
             "login": "him",
             "avatar_url": null,
-            "html_url": "http://example.com/him"
+            "html_url": "example.com/him",
+            "url": "api.example.com/him"
           }
         ]""")
     } { uri =>
@@ -251,9 +254,9 @@ class RepositorySpec extends Specification {
 
       val expected = Collaborators(
         List(
-          Collaborator("him", "http://example.com/him", None),
-          Collaborator("me", "http://example.com/me", Some("http://example.com/me.png")),
-          Collaborator("you", "http://example.com/you", None)
+          Collaborator("him", "example.com/him", "api.example.com/him", None),
+          Collaborator("me", "example.com/me", "api.example.com/me", Some("example.com/me.png")),
+          Collaborator("you", "example.com/you", "api.example.com/you", None)
         )
       )
 
@@ -265,12 +268,15 @@ class RepositorySpec extends Specification {
         Ok("""[
           {
             "login": "me",
-            "avatar_url": "http://example.com/me.png",
-            "html_url": "http://example.com/me"
+            "avatar_url": "example.com/me.png",
+            "html_url": "example.com/me",
+            "url": "api.example.com/me"
+
           },
           {
             "login": "you",
-            "html_url": "http://example.com/you"
+            "html_url": "example.com/you",
+            "url": "api.example.com/you"
           }
         ]""")
     } { uri =>
@@ -279,7 +285,7 @@ class RepositorySpec extends Specification {
       val collaborators = repository.collaborators(List("me"))
 
       val expected = Collaborators(
-        List(Collaborator("me", "http://example.com/me", Some("http://example.com/me.png")))
+        List(Collaborator("me", "example.com/me", "api.example.com/me", Some("example.com/me.png")))
       )
 
       collaborators must beRight(expected)

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
@@ -15,6 +15,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": {
               "spdx_id": "id",
               "url": "http://example.com"
@@ -30,7 +31,8 @@ class RepositorySpec extends Specification {
         License("id", "http://example.com"),
         "http://example.com/repository",
         2011,
-        "http://api.github.com/repos/example/example/contributors"
+        "http://api.github.com/repos/example/example/contributors",
+        "http://api.github.com/repos/example/example/collaborators"
       )
 
       repository must beRight(expected)
@@ -43,6 +45,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": {
               "spdx_id": "id",
               "url": "http://example.com"
@@ -65,6 +68,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": null
           }""")
     } { uri =>
@@ -84,6 +88,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": {
               "spdx_id": null,
               "url": "http://example.com"
@@ -106,6 +111,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": {
               "spdx_id": "id",
               "url": null
@@ -128,6 +134,7 @@ class RepositorySpec extends Specification {
             "html_url": "http://example.com/repository",
             "created_at": "2011-01-26T19:01:12Z",
             "contributors_url": "http://api.github.com/repos/example/example/contributors",
+            "collaborators_url": "http://api.github.com/repos/example/example/collaborators",
             "license": 42
           }""")
     } { uri =>
@@ -165,7 +172,7 @@ class RepositorySpec extends Specification {
         ]
         """)
     } { uri =>
-      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors")
+      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors", "")
 
       val contributors = repository.contributors(Nil)
 
@@ -196,7 +203,7 @@ class RepositorySpec extends Specification {
         ]
         """)
     } { uri =>
-      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors")
+      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors", "")
 
       val contributors = repository.contributors(List("you"))
 
@@ -208,7 +215,7 @@ class RepositorySpec extends Specification {
     "return generic error on any error" >> withServer {
       case GET -> Root / "contributors" => Ok("""{"hello": "hi"}""")
     } { uri =>
-      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors")
+      val repository = Repository("", License("", ""), "", 0, s"${uri}contributors", "")
 
       val contributors = repository.contributors(Nil)
 

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/UserSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/UserSpec.scala
@@ -1,0 +1,22 @@
+package com.alejandrohdezma.sbt.me.github
+
+import com.alejandrohdezma.sbt.me.json.Json
+import com.alejandrohdezma.sbt.me.syntax.json._
+import org.specs2.mutable.Specification
+
+class UserSpec extends Specification {
+
+  "Decoder[User]" should {
+
+    "treat empty email/name as None" >> {
+      val json = Json.parse("""{
+        "name": "",
+        "email": ""
+      }""")
+
+      json.as[User] must beRight(User(None, None))
+    }
+
+  }
+
+}


### PR DESCRIPTION
# What has been done in this 

- Add setting with a repository's collaborators
- Add setting to always include some collaborators to the previous list (by default, only collaborators who are also contributors will be added)
- Add example of automatically update AUTHORS.md file with collaborators
