### PR TITLE
Add collaborators informatino as developers to POM

### DIFF
--- a/src/main/scala/com/alejandrohdezma/sbt/me/Lazy.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/Lazy.scala
@@ -1,0 +1,13 @@
+package com.alejandrohdezma.sbt.me
+
+final class Lazy[T](t: => T) {
+
+  lazy val value: T = t
+
+}
+
+object Lazy {
+
+  def apply[T](t: => T): Lazy[T] = new Lazy[T](t)
+
+}

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -81,9 +81,10 @@ object SbtMePlugin extends AutoPlugin {
         .fold(sys.error, identity)
         .include(extraCollaborators.value.map(_.value))
     },
-    homepage  := repository.value.map(r => url(r.url)).orElse(homepage.value),
-    licenses  := repository.value.map(_.licenses).getOrElse(licenses.value),
-    startYear := repository.value.map(_.startYear).orElse(startYear.value)
+    developers := collaborators.value.developers,
+    homepage   := repository.value.map(r => url(r.url)).orElse(homepage.value),
+    licenses   := repository.value.map(_.licenses).getOrElse(licenses.value),
+    startYear  := repository.value.map(_.startYear).orElse(startYear.value)
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -40,7 +40,7 @@ object SbtMePlugin extends AutoPlugin {
       "List of collaborators downloaded from Github"
     )
 
-    val extraCollaborators = settingKey[List[Collaborator]] {
+    val extraCollaborators = settingKey[List[Lazy[Collaborator]]] {
       "Extra collaborators that should be always included (independent of whether they are contributors or not)"
     }
 
@@ -79,7 +79,7 @@ object SbtMePlugin extends AutoPlugin {
     collaborators := repository.value.fold(Collaborators(Nil)) {
       _.collaborators(contributors.value.list.map(_.login))
         .fold(sys.error, identity)
-        .include(extraCollaborators.value)
+        .include(extraCollaborators.value.map(_.value))
     },
     homepage  := repository.value.map(r => url(r.url)).orElse(homepage.value),
     licenses  := repository.value.map(_.licenses).getOrElse(licenses.value),

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -21,17 +21,39 @@ object Collaborator {
    * @param login the Github login ID for the collaborator
    * @param name the collaborator's full name
    * @param url the collaborator's URL. It may link to its Github profile or personal webpage.
+   * @return a new collaborator
+   */
+  def apply(login: String, name: String, url: String): Collaborator =
+    new Collaborator(login, url, "", Some(name), None, None)
+
+  /**
+   * Creates a new collaborator
+   *
+   * @param login the Github login ID for the collaborator
+   * @param name the collaborator's full name
+   * @param url the collaborator's URL. It may link to its Github profile or personal webpage.
+   * @param email the collaborator's email
+   * @return a new collaborator
+   */
+  def apply(login: String, name: String, url: String, email: String): Collaborator =
+    new Collaborator(login, url, "", Some(name), Some(email), None)
+
+  /**
+   * Creates a new collaborator
+   *
+   * @param login the Github login ID for the collaborator
+   * @param name the collaborator's full name
+   * @param url the collaborator's URL. It may link to its Github profile or personal webpage.
    * @param email the collaborator's email, optional
    * @param avatar the collaborator's avatar URL, optional
    * @return a new collaborator
    */
-  @SuppressWarnings(Array("scalafix:DisableSyntax.defaultArgs"))
   def apply(
       login: String,
       name: String,
       url: String,
-      email: Option[String] = None,
-      avatar: Option[String] = None
+      email: Option[String],
+      avatar: Option[String]
   ): Collaborator =
     new Collaborator(login, url, "", Some(name), email, avatar)
 

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -1,6 +1,7 @@
 package com.alejandrohdezma.sbt.me.github
 
 import com.alejandrohdezma.sbt.me.Lazy
+import com.alejandrohdezma.sbt.me.http.client
 import com.alejandrohdezma.sbt.me.json.Decoder
 import com.alejandrohdezma.sbt.me.syntax.json._
 
@@ -15,6 +16,15 @@ final case class Collaborator private[me] (
 )
 
 object Collaborator {
+
+  /** Obtains a collaborator information from its Github login ID */
+  def github(id: String): Lazy[Collaborator] = Lazy {
+    val userUrl = implicitly[urls.User].get(id)
+
+    client.get[User](userUrl).map { user =>
+      new Collaborator(user.login, user.url, userUrl, user.name, user.email, user.avatar)
+    } fold (_ => sys.error(s"Unable to get info for user $id"), identity)
+  }
 
   /**
    * Creates a new collaborator

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -19,9 +19,9 @@ object Collaborator {
    * Creates a new collaborator
    *
    * @param login the Github login ID for the collaborator
-   * @param url the collaborator's URL. It may link to its Github profile or personal webpage, optional
    * @param name the collaborator's full name
-   * @param email the collaborator's email
+   * @param url the collaborator's URL. It may link to its Github profile or personal webpage.
+   * @param email the collaborator's email, optional
    * @param avatar the collaborator's avatar URL, optional
    * @return a new collaborator
    */
@@ -29,11 +29,11 @@ object Collaborator {
   def apply(
       login: String,
       name: String,
-      email: String,
-      url: Option[String] = None,
+      url: String,
+      email: Option[String] = None,
       avatar: Option[String] = None
   ): Collaborator =
-    new Collaborator(login, url.getOrElse(""), "", Some(name), Some(email), avatar)
+    new Collaborator(login, url, "", Some(name), email, avatar)
 
   implicit val CollaboratorDecoder: Decoder[Collaborator] = json =>
     for {

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborator.scala
@@ -1,5 +1,6 @@
 package com.alejandrohdezma.sbt.me.github
 
+import com.alejandrohdezma.sbt.me.Lazy
 import com.alejandrohdezma.sbt.me.json.Decoder
 import com.alejandrohdezma.sbt.me.syntax.json._
 
@@ -23,8 +24,9 @@ object Collaborator {
    * @param url the collaborator's URL. It may link to its Github profile or personal webpage.
    * @return a new collaborator
    */
-  def apply(login: String, name: String, url: String): Collaborator =
+  def apply(login: String, name: String, url: String): Lazy[Collaborator] = Lazy {
     new Collaborator(login, url, "", Some(name), None, None)
+  }
 
   /**
    * Creates a new collaborator
@@ -35,8 +37,9 @@ object Collaborator {
    * @param email the collaborator's email
    * @return a new collaborator
    */
-  def apply(login: String, name: String, url: String, email: String): Collaborator =
+  def apply(login: String, name: String, url: String, email: String): Lazy[Collaborator] = Lazy {
     new Collaborator(login, url, "", Some(name), Some(email), None)
+  }
 
   /**
    * Creates a new collaborator
@@ -54,8 +57,9 @@ object Collaborator {
       url: String,
       email: Option[String],
       avatar: Option[String]
-  ): Collaborator =
+  ): Lazy[Collaborator] = Lazy {
     new Collaborator(login, url, "", Some(name), email, avatar)
+  }
 
   implicit val CollaboratorDecoder: Decoder[Collaborator] = json =>
     for {

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Collaborators.scala
@@ -1,5 +1,7 @@
 package com.alejandrohdezma.sbt.me.github
 
+import sbt.librarymanagement.Developer
+
 /** Represents a repository's list of collaborators */
 final case class Collaborators(list: List[Collaborator]) {
 
@@ -11,6 +13,13 @@ final case class Collaborators(list: List[Collaborator]) {
       .toList
       .map(_.head) /* scalafix:ok */
       .sortBy(collaborator => collaborator.name -> collaborator.login)
+  }
+
+  /** Returns this list of collaborators as SBT developers */
+  lazy val developers: List[Developer] = list.map { collaborator =>
+    import collaborator._
+
+    Developer(login, name.getOrElse(login), email.getOrElse(""), sbt.url(url))
   }
 
   /** Returns this list of collaborators in markdown format */

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/User.scala
@@ -3,14 +3,29 @@ package com.alejandrohdezma.sbt.me.github
 import com.alejandrohdezma.sbt.me.json.Decoder
 import com.alejandrohdezma.sbt.me.syntax.json._
 
-final case class User(name: Option[String], email: Option[String])
+final case class User(
+    login: String,
+    url: String,
+    name: Option[String],
+    email: Option[String],
+    avatar: Option[String]
+)
 
 object User {
 
   implicit val decoder: Decoder[User] = json =>
     for {
-      name  <- json.get[Option[String]]("name")
-      email <- json.get[Option[String]]("email")
-    } yield User(name.filter(_.nonEmpty), email.filter(_.nonEmpty))
+      login  <- json.get[String]("login")
+      url    <- json.get[String]("html_url")
+      name   <- json.get[Option[String]]("name")
+      email  <- json.get[Option[String]]("email")
+      avatar <- json.get[Option[String]]("avatar_url")
+    } yield User(
+      login,
+      url,
+      name.filter(_.nonEmpty),
+      email.filter(_.nonEmpty),
+      avatar.filter(_.nonEmpty)
+    )
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/urls/User.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/urls/User.scala
@@ -1,0 +1,22 @@
+package com.alejandrohdezma.sbt.me.github.urls
+
+import com.alejandrohdezma.sbt.me.http.client
+import com.alejandrohdezma.sbt.me.json.Decoder
+import com.alejandrohdezma.sbt.me.syntax.json._
+
+final case class User(base: String) {
+
+  def get(login: String): String = base.replace("{user}", login)
+
+}
+
+object User {
+
+  implicit lazy val user: User =
+    client
+      .get[User]("https://api.github.com")
+      .getOrElse(sys.error("Unable to connect to Github"))
+
+  implicit val UserUrlDecoder: Decoder[User] = json => json.get[String]("user_url").map(User(_))
+
+}

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -9,18 +9,18 @@ class CollaboratorsSpec extends Specification {
     "return list of collaborators including new ones" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("me", "Me", "me@example.com"),
-          Collaborator("you", "You", "you@example.com")
+          Collaborator("me", "Me", "example.com/me"),
+          Collaborator("you", "You", "example.com/you")
         )
       )
 
-      val extra = List(Collaborator("him", "Him", "him@example.com"))
+      val extra = List(Collaborator("him", "Him", "example.com/him"))
 
       val expected = Collaborators(
         List(
-          Collaborator("him", "Him", "him@example.com"),
-          Collaborator("me", "Me", "me@example.com"),
-          Collaborator("you", "You", "you@example.com")
+          Collaborator("him", "Him", "example.com/him"),
+          Collaborator("me", "Me", "example.com/me"),
+          Collaborator("you", "You", "example.com/you")
         )
       )
 
@@ -30,17 +30,17 @@ class CollaboratorsSpec extends Specification {
     "remove duplicates" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("me", "Me", "me@example.com"),
-          Collaborator("you", "You", "you@example.com")
+          Collaborator("me", "Me", "example.com/me"),
+          Collaborator("you", "You", "example.com/you")
         )
       )
 
-      val extra = List(Collaborator("me", "MeMe", "meme@example.com"))
+      val extra = List(Collaborator("me", "MeMe", "example.com/meme"))
 
       val expected = Collaborators(
         List(
-          Collaborator("me", "Me", "me@example.com"),
-          Collaborator("you", "You", "you@example.com")
+          Collaborator("me", "Me", "example.com/me"),
+          Collaborator("you", "You", "example.com/you")
         )
       )
 
@@ -51,31 +51,31 @@ class CollaboratorsSpec extends Specification {
 
   "Collaborators.markdown" should {
 
-    "return contributor list as markdown" >> {
+    "return collaborator list as markdown" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("her", "Her", "her@example.com", avatar = Some("example.com/her.png")),
-          Collaborator("him", "Him", "him@example.com"),
+          Collaborator("her", "Her", "example.com/her", avatar = Some("example.com/her.png")),
+          Collaborator("him", "Him", "example.com/him"),
           Collaborator(
             "it",
             "It",
-            "it@example.com",
-            Some("example.com/it"),
+            "example.com/it",
+            Some("it@example.com"),
             Some("example.com/it.png")
           ),
-          Collaborator("me", "Me", "me@example.com", Some("example.com/me")),
-          Collaborator("you", "", "you@example.com")
+          Collaborator("me", "Me", "example.com/me", Some("me@example.com")),
+          Collaborator("you", "", "example.com/you")
         )
       )
 
       val markdown = collaborators.markdown
 
       val expected =
-        """- ![her](example.com/her.png&s=20) **Her (her)**
-          |- **Him (him)**
+        """- [![her](example.com/her.png&s=20) **Her (her)**](example.com/her)
+          |- [**Him (him)**](example.com/him)
           |- [![it](example.com/it.png&s=20) **It (it)**](example.com/it)
           |- [**Me (me)**](example.com/me)
-          |- **you**""".stripMargin
+          |- [**you**](example.com/you)""".stripMargin
 
       markdown must be equalTo expected
     }

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -9,18 +9,18 @@ class CollaboratorsSpec extends Specification {
     "return list of collaborators including new ones" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("me", "Me", "example.com/me"),
-          Collaborator("you", "You", "example.com/you")
+          new Collaborator("me", "example.com/me", "", Some("Me"), None, None),
+          new Collaborator("you", "example.com/you", "", Some("You"), None, None)
         )
       )
 
-      val extra = List(Collaborator("him", "Him", "example.com/him"))
+      val extra = List(new Collaborator("him", "example.com/him", "", Some("Him"), None, None))
 
       val expected = Collaborators(
         List(
-          Collaborator("him", "Him", "example.com/him"),
-          Collaborator("me", "Me", "example.com/me"),
-          Collaborator("you", "You", "example.com/you")
+          new Collaborator("him", "example.com/him", "", Some("Him"), None, None),
+          new Collaborator("me", "example.com/me", "", Some("Me"), None, None),
+          new Collaborator("you", "example.com/you", "", Some("You"), None, None)
         )
       )
 
@@ -30,17 +30,17 @@ class CollaboratorsSpec extends Specification {
     "remove duplicates" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("me", "Me", "example.com/me"),
-          Collaborator("you", "You", "example.com/you")
+          new Collaborator("me", "example.com/me", "", Some("Me"), None, None),
+          new Collaborator("you", "example.com/you", "", Some("You"), None, None)
         )
       )
 
-      val extra = List(Collaborator("me", "MeMe", "example.com/meme"))
+      val extra = List(new Collaborator("me", "example.com/meme", "", Some("MeMe"), None, None))
 
       val expected = Collaborators(
         List(
-          Collaborator("me", "Me", "example.com/me"),
-          Collaborator("you", "You", "example.com/you")
+          new Collaborator("me", "example.com/me", "", Some("Me"), None, None),
+          new Collaborator("you", "example.com/you", "", Some("You"), None, None)
         )
       )
 
@@ -54,17 +54,25 @@ class CollaboratorsSpec extends Specification {
     "return collaborator list as markdown" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("her", "Her", "example.com/her", None, Some("example.com/her.png")),
-          Collaborator("him", "Him", "example.com/him"),
-          Collaborator(
+          new Collaborator(
+            "her",
+            "example.com/her",
+            "",
+            Some("Her"),
+            None,
+            Some("example.com/her.png")
+          ),
+          new Collaborator("him", "example.com/him", "", Some("Him"), None, None),
+          new Collaborator(
             "it",
-            "It",
             "example.com/it",
+            "",
+            Some("It"),
             Some("it@example.com"),
             Some("example.com/it.png")
           ),
-          Collaborator("me", "Me", "example.com/me", "me@example.com"),
-          Collaborator("you", "", "example.com/you")
+          new Collaborator("me", "example.com/me", "", Some("Me"), Some("me@example.com"), None),
+          new Collaborator("you", "example.com/you", "", Some(""), None, None)
         )
       )
 

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -54,7 +54,7 @@ class CollaboratorsSpec extends Specification {
     "return collaborator list as markdown" >> {
       val collaborators = Collaborators(
         List(
-          Collaborator("her", "Her", "example.com/her", avatar = Some("example.com/her.png")),
+          Collaborator("her", "Her", "example.com/her", None, Some("example.com/her.png")),
           Collaborator("him", "Him", "example.com/him"),
           Collaborator(
             "it",
@@ -63,7 +63,7 @@ class CollaboratorsSpec extends Specification {
             Some("it@example.com"),
             Some("example.com/it.png")
           ),
-          Collaborator("me", "Me", "example.com/me", Some("me@example.com")),
+          Collaborator("me", "Me", "example.com/me", "me@example.com"),
           Collaborator("you", "", "example.com/you")
         )
       )

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/CollaboratorsSpec.scala
@@ -1,5 +1,7 @@
 package com.alejandrohdezma.sbt.me.github
 
+import sbt.librarymanagement.Developer
+
 import org.specs2.mutable.Specification
 
 class CollaboratorsSpec extends Specification {
@@ -86,6 +88,32 @@ class CollaboratorsSpec extends Specification {
           |- [**you**](example.com/you)""".stripMargin
 
       markdown must be equalTo expected
+    }
+
+  }
+
+  "Collaborators.developers" should {
+
+    "return collaborators as list of developers" >> {
+      val collaborators = Collaborators(
+        List(
+          new Collaborator("her", "http://example.com/her", "", Some("Her"), None, None),
+          new Collaborator("him", "http://example.com/him", "", Some("Him"), None, None),
+          new Collaborator("it", "http://example.com/it", "", None, Some("it@example.com"), None),
+          new Collaborator("me", "http://example.com/me", "", Some("Me"), None, None),
+          new Collaborator("you", "http://example.com/you", "", Some(""), None, None)
+        )
+      )
+
+      val expected = List(
+        Developer("her", "Her", "", sbt.url("http://example.com/her")),
+        Developer("him", "Him", "", sbt.url("http://example.com/him")),
+        Developer("it", "it", "it@example.com", sbt.url("http://example.com/it")),
+        Developer("me", "Me", "", sbt.url("http://example.com/me")),
+        Developer("you", "", "", sbt.url("http://example.com/you"))
+      )
+
+      collaborators.developers must be equalTo expected
     }
 
   }

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
@@ -228,9 +228,22 @@ class RepositorySpec extends Specification {
   "repository.collaborators" should {
 
     "return list of collaborators (alphabetically ordered) with user info from Github API" >> withServer {
-      case GET -> Root / "me"  => Ok("""{"name": "Me", "email": "me@example.com"}""")
-      case GET -> Root / "you" => Ok("""{"name": "You"}""")
-      case GET -> Root / "him" => Ok("""{"email": "him@example.com"}""")
+      case GET -> Root / "me"  => Ok("""{
+        "name": "Me",
+        "login": "me",
+        "html_url": "example.com/me",
+        "email": "me@example.com"
+      }""")
+      case GET -> Root / "you" => Ok("""{
+        "login": "you",
+        "html_url": "example.com/you",
+        "avatar_url": "example.com/you.png"
+      }""")
+      case GET -> Root / "him" => Ok("""{
+        "name": "Him",
+        "login": "him",
+        "html_url": "example.com/him"
+      }""")
       case req @ GET -> Root / "collaborators" =>
         val host = req.headers.get(Host).getOrElse(Host(""))
 
@@ -262,7 +275,8 @@ class RepositorySpec extends Specification {
 
       val expected = Collaborators(
         List(
-          Collaborator("him", "example.com/him", s"${uri}him", None, Some("him@example.com"), None),
+          Collaborator("you", "example.com/you", s"${uri}you", None, None, None),
+          Collaborator("him", "example.com/him", s"${uri}him", Some("Him"), None, None),
           Collaborator(
             "me",
             "example.com/me",
@@ -270,8 +284,7 @@ class RepositorySpec extends Specification {
             Some("Me"),
             Some("me@example.com"),
             Some("example.com/me.png")
-          ),
-          Collaborator("you", "example.com/you", s"${uri}you", Some("You"), None, None)
+          )
         )
       )
 
@@ -279,7 +292,8 @@ class RepositorySpec extends Specification {
     }
 
     "exclude collaborators not in provided list and don't retrieve user info for them" >> withServer {
-      case GET -> Root / "me" => Ok("""{"name": "Me", "email": "me@example.com"}""")
+      case GET -> Root / "me" =>
+        Ok("""{"login": "me", "html_url": "example.com/me", "name": "Me"}""")
       case req @ GET -> Root / "collaborators" =>
         val host = req.headers.get(Host).getOrElse(Host(""))
 
@@ -305,12 +319,12 @@ class RepositorySpec extends Specification {
 
       val expected = Collaborators(
         List(
-          Collaborator(
+          new Collaborator(
             "me",
             "example.com/me",
             s"${uri}me",
             Some("Me"),
-            Some("me@example.com"),
+            None,
             Some("example.com/me.png")
           )
         )

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/UserSpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/UserSpec.scala
@@ -8,13 +8,18 @@ class UserSpec extends Specification {
 
   "Decoder[User]" should {
 
-    "treat empty email/name as None" >> {
+    "treat empty email/name/avatar as None" >> {
       val json = Json.parse("""{
+        "login": "me",
+        "html_url": "example.com/me",
+        "avatar": "",
         "name": "",
         "email": ""
       }""")
 
-      json.as[User] must beRight(User(None, None))
+      val expected = User("me", "example.com/me", None, None, None)
+
+      json.as[User] must beRight(expected)
     }
 
   }


### PR DESCRIPTION
# What has been done in this PR?

- Transform collaborators information to SBT developers and populate `developers` settings with them.
- Create method for obtaining a collaborator information directly from Github