### PR TITLE
Add organization information as POM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,13 +5,19 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 
 lazy val `sbt-me` = project
   .in(file("."))
-  .enablePlugins(SbtPlugin, MdocPlugin)
+  .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
       "org.specs2" %% "specs2-core"         % "4.8.3"   % Test,
       "org.http4s" %% "http4s-dsl"          % "0.20.15" % Test,
       "org.http4s" %% "http4s-blaze-server" % "0.20.15" % Test
-    ),
+    )
+  )
+
+lazy val `sbt-me-docs` = project
+  .enablePlugins(MdocPlugin)
+  .settings(skip in publish := true)
+  .settings(
     mdocVariables := Map(
       "VERSION"       -> version.value.replaceAll("\\+.*", ""),
       "CONTRIBUTORS"  -> contributors.value.markdown,

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,10 @@ lazy val `sbt-me` = project
   .enablePlugins(SbtPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "org.specs2" %% "specs2-core"         % "4.8.3"   % Test,
-      "org.http4s" %% "http4s-dsl"          % "0.20.15" % Test,
-      "org.http4s" %% "http4s-blaze-server" % "0.20.15" % Test
+      "org.specs2"     %% "specs2-core"         % "4.8.3"   % Test,
+      "org.http4s"     %% "http4s-dsl"          % "0.20.15" % Test,
+      "org.http4s"     %% "http4s-blaze-server" % "0.20.15" % Test,
+      "ch.qos.logback" % "logback-classic"      % "1.2.3"   % Test
     )
   )
 

--- a/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -88,7 +88,16 @@ object SbtMePlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    description := repository.value.map(_.description).getOrElse(description.value)
+    description := repository.value.map(_.description).getOrElse(description.value),
+    organizationName := repository.value
+      .flatMap(_.organization)
+      .flatMap(_.fold(sys.error, identity).name)
+      .getOrElse(organizationName.value),
+    organizationHomepage := repository.value
+      .flatMap(_.organization)
+      .flatMap(_.fold(sys.error, identity).url)
+      .map(sbt.url)
+      .orElse(organizationHomepage.value)
   )
 
   /** Gets the Github user and repository from the git remote info */

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Organization.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Organization.scala
@@ -1,0 +1,17 @@
+package com.alejandrohdezma.sbt.me.github
+
+import com.alejandrohdezma.sbt.me.json.Decoder
+import com.alejandrohdezma.sbt.me.syntax.json._
+
+/** Represents a repository's organization */
+final case class Organization(name: Option[String], url: Option[String])
+
+object Organization {
+
+  implicit val OrganizationDecoder: Decoder[Organization] = json =>
+    for {
+      name <- json.get[Option[String]]("name")
+      url  <- json.get[Option[String]]("blog")
+    } yield Organization(name, url)
+
+}

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
@@ -62,6 +62,14 @@ final case class Repository(
       .map(Collaborators)
       .leftMap(_ => "Unable to get repository collaborators")
 
+  /**
+   * Returns the repository's organization information, if present.
+   */
+  def organization(implicit auth: Authentication): Option[Either[String, Organization]] =
+    organizationUrl
+      .map(client.get[Organization])
+      .map(_.leftMap(_ => "Unable to get repository organization"))
+
 }
 
 object Repository {

--- a/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/github/Repository.scala
@@ -18,7 +18,8 @@ final case class Repository(
     url: String,
     startYear: Int,
     contributorsUrl: String,
-    collaboratorsUrl: String
+    collaboratorsUrl: String,
+    organizationUrl: Option[String]
 ) {
 
   /** Returns the license extracted from github in the format that SBT is expecting */
@@ -84,19 +85,26 @@ object Repository {
 
   implicit val RepositoryDecoder: Decoder[Repository] = json =>
     for {
-      description   <- json.get[String]("description")
-      license       <- json.get[License]("license")
-      url           <- json.get[String]("html_url")
-      startYear     <- json.get[ZonedDateTime]("created_at")
-      contributors  <- json.get[String]("contributors_url")
-      collaborators <- json.get[String]("collaborators_url")
+      description     <- json.get[String]("description")
+      license         <- json.get[License]("license")
+      url             <- json.get[String]("html_url")
+      startYear       <- json.get[ZonedDateTime]("created_at")
+      contributors    <- json.get[String]("contributors_url")
+      collaborators   <- json.get[String]("collaborators_url")
+      organizationUrl <- json.get[Option[OrganizationUrl]]("organization")
     } yield Repository(
       description,
       license,
       url,
       startYear.getYear,
       contributors,
-      collaborators.replace("{/collaborator}", "")
+      collaborators.replace("{/collaborator}", ""),
+      organizationUrl.map(_.value)
     )
+
+  final private case class OrganizationUrl(value: String) extends AnyVal
+
+  implicit private val OrganizationUrlDecoder: Decoder[OrganizationUrl] =
+    _.get[String]("url").map(OrganizationUrl)
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/http/client.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/http/client.scala
@@ -1,11 +1,16 @@
 package com.alejandrohdezma.sbt.me.http
 
+import java.io.FileNotFoundException
 import java.net.{HttpURLConnection, URL}
 
 import scala.io.Source
+import scala.util.Try
+import scala.util.control.NonFatal
 
-import com.alejandrohdezma.sbt.me.json.Json.Result
+import com.alejandrohdezma.sbt.me.json.Json.Fail.NotFound
+import com.alejandrohdezma.sbt.me.json.Json.{Fail, Result}
 import com.alejandrohdezma.sbt.me.json.{Decoder, Json}
+import com.alejandrohdezma.sbt.me.syntax.either._
 import com.alejandrohdezma.sbt.me.syntax.json._
 
 object client {
@@ -15,18 +20,20 @@ object client {
    * returns its contents as `String`.
    */
   @SuppressWarnings(Array("all"))
-  def get[A: Decoder](uri: String)(implicit A: Authentication): Result[A] = {
-    val url = new URL(s"$uri")
+  def get[A: Decoder](uri: String)(implicit A: Authentication): Result[A] =
+    Try {
+      val url = new URL(s"$uri")
 
-    val connection = url.openConnection.asInstanceOf[HttpURLConnection]
+      val connection = url.openConnection.asInstanceOf[HttpURLConnection]
 
-    connection.setRequestProperty("Authorization", A.header)
+      connection.setRequestProperty("Authorization", A.header)
 
-    val inputStream = connection.getInputStream
+      val inputStream = connection.getInputStream
 
-    val content = Source.fromInputStream(inputStream, "UTF-8").mkString
-
-    Json.parse(content).as[A]
-  }
+      Source.fromInputStream(inputStream, "UTF-8").mkString
+    }.toEither.leftMap {
+      case _: FileNotFoundException => NotFound
+      case NonFatal(_)              => Fail.Unknown
+    }.flatMap(Json.parse).as[A]
 
 }

--- a/src/main/scala/com/alejandrohdezma/sbt/me/json/Json.scala
+++ b/src/main/scala/com/alejandrohdezma/sbt/me/json/Json.scala
@@ -44,6 +44,7 @@ object Json extends JavaTokenParsers {
     final case class Path(value: String, fail: Fail)   extends Fail
     case object NotAValidJSON                          extends Fail
     case object NotFound                               extends Fail
+    case object Unknown                                extends Fail
 
   }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <logger name="org.http4s.server" level="off"/>
+</configuration>

--- a/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
@@ -395,4 +395,57 @@ class RepositorySpec extends Specification {
 
   }
 
+  "repository.organization" should {
+
+    "return repository's organization from Github API" >> withServer {
+      case GET -> Root / "organization" =>
+        Ok(s"""{ "name": "My Organization", "blog": "http://example.com" }""")
+    } { uri =>
+      val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
+
+      val organization = repository.organization
+
+      val expected = Organization(Some("My Organization"), Some("http://example.com"))
+
+      organization must be some right(expected)
+    }
+
+    "not return url if not present" >> withServer {
+      case GET -> Root / "organization" =>
+        Ok(s"""{ "name": "My Organization"}""")
+    } { uri =>
+      val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
+
+      val organization = repository.organization
+
+      val expected = Organization(Some("My Organization"), None)
+
+      organization must be some right(expected)
+    }
+
+    "not return name if not present" >> withServer {
+      case GET -> Root / "organization" =>
+        Ok(s"""{ "blog": "http://example.com" }""")
+    } { uri =>
+      val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
+
+      val organization = repository.organization
+
+      val expected = Organization(None, Some("http://example.com"))
+
+      organization must be some right(expected)
+    }
+
+    "return generic error on any error" >> withServer {
+      case GET -> Root / "organization" => NotFound()
+    } { uri =>
+      val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
+
+      val collaborators = repository.organization
+
+      collaborators must be some left("Unable to get repository organization")
+    }
+
+  }
+
 }

--- a/src/test/scala/com/alejandrohdezma/sbt/me/package.scala
+++ b/src/test/scala/com/alejandrohdezma/sbt/me/package.scala
@@ -15,6 +15,7 @@ package object me {
     implicit val timer: Timer[IO]     = IO.timer(global)
 
     BlazeServerBuilder[IO]
+      .withNio2(true)
       .bindAny()
       .withHttpApp(HttpRoutes.of[IO](pf).orNotFound)
       .resource


### PR DESCRIPTION
# What has been done in this PR?

- Add method to obtain a repository's organization
- Add organization information to SBT settings `organizationHomepage` and `organizationName`
