### PR TITLE
Retrieve organization email from Github

### DIFF
--- a/sbt-me/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
+++ b/sbt-me/src/main/scala/com/alejandrohdezma/sbt/me/SbtMePlugin.scala
@@ -61,6 +61,10 @@ object SbtMePlugin extends AutoPlugin {
       "Range of years in which the project has been active"
     }
 
+    val organizationEmail = settingKey[Option[String]] {
+      "Organization email"
+    }
+
   }
 
   import autoImport._
@@ -106,7 +110,10 @@ object SbtMePlugin extends AutoPlugin {
       .flatMap(_.organization)
       .flatMap(_.fold(sys.error, identity).url)
       .map(sbt.url)
-      .orElse(organizationHomepage.value)
+      .orElse(organizationHomepage.value),
+    organizationEmail := repository.value
+      .flatMap(_.organization)
+      .flatMap(_.fold(sys.error, identity).email)
   )
 
   /** Gets the Github user and repository from the git remote info */

--- a/sbt-me/src/main/scala/com/alejandrohdezma/sbt/me/github/Organization.scala
+++ b/sbt-me/src/main/scala/com/alejandrohdezma/sbt/me/github/Organization.scala
@@ -4,14 +4,15 @@ import com.alejandrohdezma.sbt.me.json.Decoder
 import com.alejandrohdezma.sbt.me.syntax.json._
 
 /** Represents a repository's organization */
-final case class Organization(name: Option[String], url: Option[String])
+final case class Organization(name: Option[String], url: Option[String], email: Option[String])
 
 object Organization {
 
   implicit val OrganizationDecoder: Decoder[Organization] = json =>
     for {
-      name <- json.get[Option[String]]("name")
-      url  <- json.get[Option[String]]("blog")
-    } yield Organization(name, url)
+      name  <- json.get[Option[String]]("name")
+      url   <- json.get[Option[String]]("blog")
+      email <- json.get[Option[String]]("email")
+    } yield Organization(name, url, email)
 
 }

--- a/sbt-me/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
+++ b/sbt-me/src/test/scala/com/alejandrohdezma/sbt/me/github/RepositorySpec.scala
@@ -401,39 +401,57 @@ class RepositorySpec extends Specification {
 
     "return repository's organization from Github API" >> withServer {
       case GET -> Root / "organization" =>
-        Ok(s"""{ "name": "My Organization", "blog": "http://example.com" }""")
+        Ok(s"""{
+          "name": "My Organization",
+          "blog": "http://example.com",
+          "email": "org@example.com"
+        }""")
     } { uri =>
       val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
 
       val organization = repository.organization
 
-      val expected = Organization(Some("My Organization"), Some("http://example.com"))
+      val expected =
+        Organization(Some("My Organization"), Some("http://example.com"), Some("org@example.com"))
 
       organization must be some right(expected)
     }
 
     "not return url if not present" >> withServer {
       case GET -> Root / "organization" =>
-        Ok(s"""{ "name": "My Organization"}""")
+        Ok(s"""{ "name": "My Organization", "email": "org@example.com" }""")
     } { uri =>
       val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
 
       val organization = repository.organization
 
-      val expected = Organization(Some("My Organization"), None)
+      val expected = Organization(Some("My Organization"), None, Some("org@example.com"))
 
       organization must be some right(expected)
     }
 
     "not return name if not present" >> withServer {
       case GET -> Root / "organization" =>
-        Ok(s"""{ "blog": "http://example.com" }""")
+        Ok(s"""{ "blog": "http://example.com", "email": "org@example.com" }""")
     } { uri =>
       val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
 
       val organization = repository.organization
 
-      val expected = Organization(None, Some("http://example.com"))
+      val expected = Organization(None, Some("http://example.com"), Some("org@example.com"))
+
+      organization must be some right(expected)
+    }
+
+    "not return email if not present" >> withServer {
+      case GET -> Root / "organization" =>
+        Ok(s"""{ "blog": "http://example.com", "name": "My Organization" }""")
+    } { uri =>
+      val repository = Repository("", License("", ""), "", 0, "", "", Some(s"${uri}organization"))
+
+      val organization = repository.organization
+
+      val expected = Organization(Some("My Organization"), Some("http://example.com"), None)
 
       organization must be some right(expected)
     }


### PR DESCRIPTION
# What has been done in this PR?

- Recover org email from repository's API
- Add email as setting in `SbtMePlugin`
- Create setting `organizationMetadata` to avoid making multiple calls to API